### PR TITLE
android-sdk: fix options

### DIFF
--- a/src/android-sdk/devcontainer-feature.json
+++ b/src/android-sdk/devcontainer-feature.json
@@ -18,6 +18,16 @@
             "type": "string",
             "default": "34.0.0",
             "description": "SDK build-tools version"
+        },
+        "base_packages": {
+            "type": "string",
+            "default": "",
+            "description": "packages will override default packages, split by space"
+        },
+        "extra_packages": {
+            "type": "string",
+            "default": "",
+            "description": "extra packages, split by space"
         }
     },
     "installsAfter": ["ghcr.io/devcontainers/features/common-utils", "ghcr.io/akhildevelops/devcontainer-features/apt"]

--- a/test/android-sdk/scenarios.json
+++ b/test/android-sdk/scenarios.json
@@ -3,7 +3,8 @@
         "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
         "features": {
             "android-sdk": {
-                "platform": "32"
+                "platform": "32",
+                "extra_packages": "ndk;25.2.9519653 sources;android-32"
             }
         }
     }

--- a/test/android-sdk/specific_sdk.sh
+++ b/test/android-sdk/specific_sdk.sh
@@ -4,5 +4,6 @@ set -e
 source dev-container-features-test-lib
 
 check "execute command" bash -c "adb --version"
+check "execute command" bash -c "sdkmanager --list_installed"
 
 reportResults

--- a/test/android-sdk/test.sh
+++ b/test/android-sdk/test.sh
@@ -4,5 +4,6 @@ set -e
 source dev-container-features-test-lib
 
 check "execute command" bash -c "adb --version"
+check "execute command" bash -c "sdkmanager --list_installed"
 
 reportResults


### PR DESCRIPTION
add usbutils
enable custom sdkmanager packages

---

https://containers.dev/implementors/features/#option-resolution

> To ensure a option that is valid as an environment variable, the follow substitutions are performed:
> `(str: string) => str`
> `	.replace(/[^\w_]/g, '_')`
> `	.replace(/^[\d_]+/g, '_')`
> `	.toUpperCase();`

