### PR TITLE
android-sdk: fix permission

### DIFF
--- a/src/android-sdk/install.sh
+++ b/src/android-sdk/install.sh
@@ -54,8 +54,8 @@ yes | sdkmanager "platform-tools" "platforms;android-$PLATFORM" "build-tools;$BU
 # Restore JAVA_HOME.
 export JAVA_HOME=$OG_JAVA_HOME
 
+# Make sure the Android SDK has the correct permissions.
+sudo chown -R "$_REMOTE_USER:$_REMOTE_USER" "$ANDROID_HOME"
+
 # Exist subshell.
 exit
-
-# Make sure the Android SDK has the correct permissions.
-chown -R "$_REMOTE_USER:$_REMOTE_USER" "$ANDROID_HOME"


### PR DESCRIPTION
https://github.com/NordcomInc/devcontainer-features/blob/15c104a3708262e55a5eea1362e6da544210c6a7/src/android-sdk/install.sh#L57-L58

It seems that this will exit the whole `install.sh`

Reproduce with:

https://github.com/NordcomInc/devcontainer-features/blob/15c104a3708262e55a5eea1362e6da544210c6a7/test/android-sdk/test.sh#L6

```
check "execute command" bash -c "ls -alh $ANDROID_HOME"
```